### PR TITLE
Add a variable for force linking the oc tool

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,6 @@ oc_privilege_escalation: True
 
 # Timeout in seconds for oc download request
 oc_download_timeout: 10
+
+# Whether the symlink should be forced or not. No for backwards compatibility.
+force_oc_link: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,7 @@
     src: '{{oc_install_dir}}/{{item}}'
     dest: '{{oc_install_parent_dir}}/{{item}}'
     state: link
+    force: '{{force_oc_link}}'
 
 - name: cleanup
   become: yes


### PR DESCRIPTION
@andrewrothstein Hello, would you mind taking a look?

Currently the link task will fail if the oc binary already exists
before attempting to create the link. If the 'force' option is set
to 'yes' then this error will not happen and the original file will
be overwritten.

To keep the original behaviour this option defaults to 'no'. Meaning
there is no issue with backwards compatibility.

The exact error is `refusing to convert between file and link for /usr/local/bin/oc`