### PR TITLE
Allow for oc unarchive to be forced

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,6 @@ oc_download_timeout: 10
 
 # Whether the symlink should be forced or not. No for backwards compatibility.
 force_oc_link: no
+
+# Whether oc should be unarchived even if it already exists.
+force_oc_unarchive: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
     remote_src: yes
     src: /tmp/{{oc_filename}}
     dest: '{{oc_unarchive_dir}}'
-    creates: '{{oc_install_dir}}/oc'
+    creates: '{{ force_oc_unarchive | ternary(None, oc_install_dir+"/oc") }}'
 
 - name: link
   become: '{{oc_privilege_escalation}}'


### PR DESCRIPTION
Hello @andrewrothstein , would you mind taking a look?

Currently when the oc binary already exists the unarchiving of the
downloaded version will be skipped. This is due to the 'creates'
field in the unarchive module being set.

This change adds a variable named force_oc_unarchive that will
allow to force the unarchiving of the downloaded oc tool
regardless of whether it currently exists or not. The new
variable is set to 'no' by default to keep backwards
compatibility.

The ternary filter used in this change was introduced in Ansible
1.9.