### PR TITLE
Update alpine glibc shim dependency name to match published name

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -35,5 +35,5 @@ galaxy_info:
 dependencies:
   - role: andrewrothstein.unarchive-deps
     version: v1.0.9
-  - role: andrewrothstein.alpine-glibc-shim
-    version: v2.0.5
+  - role: andrewrothstein.alpine_glibc_shim
+    version: v2.0.6


### PR DESCRIPTION
Currently the hyphen separated name for the glibc shim dependency
does not resolve to a published dependency in Ansible Galaxy. This
is because the name is now underscore separated.

This change updates the dependency name to an existing published
dependency.